### PR TITLE
Add support for unhexing values generated by auditd

### DIFF
--- a/lib/audit_log_parser.rb
+++ b/lib/audit_log_parser.rb
@@ -8,13 +8,13 @@ class AuditLogParser
   # @param unhex_keys [Array<String>] with * meaning all
   def self.parse(src, flatten: false, unhex: false, unhex_keys: ['*'], unhex_min_length: 8)
     # audit always uses uppercase hex digits. Fortunately addresses are generally lower-case.
-    unhex_re = /^[A-F0-9]{#{unhex_min_length},}$/  
     src.each_line.map do |line|
-      parse_line(line, flatten: flatten, unhex: unhex, unhex_keys: unhex_keys, unhex_re: unhex_re)
+      parse_line(line, flatten: flatten, unhex: unhex, unhex_keys: unhex_keys, unhex_min_length: unhex_min_length)
     end
   end
 
-  def self.parse_line(line, flatten: false, unhex: false, unhex_keys: ['*'], unhex_re: /^[A-F0-9]{8,}/)
+  def self.parse_line(line, flatten: false, unhex: false, unhex_keys: ['*'], unhex_min_length: 8)
+    unhex_re = /^[A-F0-9]{#{unhex_min_length},}$/  
     line = line.strip
 
     if line !~ /type=\w+ msg=audit\([\d.:]+\): */

--- a/lib/audit_log_parser.rb
+++ b/lib/audit_log_parser.rb
@@ -39,7 +39,7 @@ class AuditLogParser
     hash.each do |key, value|
       if value.kind_of?(Hash)
         unhex_hash!(value)
-      elsif (value.length % 2) == 0 && HEX_RE.match?(value)
+      elsif (value.length % 2) == 0 && HEX_RE.match(value)
         value[0..-1] = [value].pack("H*")
       end
     end

--- a/spec/audit_log_parser_spec.rb
+++ b/spec/audit_log_parser_spec.rb
@@ -1,7 +1,18 @@
 RSpec.describe AuditLogParser do
+  let(:unhex_audit_log) do
+    {
+      %q{type=PROCTITLE msg=audit(1585655101.154:27786): proctitle=2F62696E2F7368002D6300636F6D6D616E64202D762064656269616E2D736131203E202F6465762F6E756C6C2026262064656269616E2D73613120312031} => 
+      {"header"=>{"type"=>"PROCTITLE", "msg"=>"audit(1585655101.154:27786)"},
+      "body"=>
+        {
+          "proctitle" => "/bin/sh\u0000-c\u0000command -v debian-sa1 > /dev/null && debian-sa1 1 1", 
+        }
+      }
+    }
+  end
   let(:audit_log) do
     {
-      %q{type=SYSCALL msg=audit(1364481363.243:24287): arch=c000003e syscall=2 success=no exit=-13 a0=7fffd19c5592 a1=0 a2=7fffd19c4b50 a3=a items=1 ppid=2686 pid=3538 auid=500 uid=500 gid=500 euid=500 suid=500 fsuid=500 egid=500 sgid=500 fsgid=500 tty=pts0 ses=1 comm="cat" exe="/bin/cat" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="sshd_config"} =>
+      %q{type=SYSCALL msg=audit(1364481363.243:24287): arch=c000003e syscall=2 success=no exit=-13 a0=7fffd19c5592 a1=0 a2=7fffd19c4b50 a3=a items=1 ppid=2686 pid=3538 auid=500 uid=500 gid=500 euid=500 suid=500 fsuid=500 egid=500 sgid=500 fsgid=500  tty=pts0 ses=1 comm="cat" exe="/bin/cat" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="sshd_config"} =>
       {"header"=>{"type"=>"SYSCALL", "msg"=>"audit(1364481363.243:24287)"},
       "body"=>
         {"arch"=>"c000003e",
@@ -93,6 +104,16 @@ RSpec.describe AuditLogParser do
     specify '#parse can be parsed correctly' do
       lines = audit_log.keys.join("\n")
       expect(AuditLogParser.parse(lines)).to eq audit_log.values
+    end
+
+    specify '#parse correctly unhex proctitle' do
+      lines = unhex_audit_log.keys.join("\n")
+      expect(AuditLogParser.parse(lines, unhex: true)).to eq unhex_audit_log.values
+    end
+
+    specify '#parse unhex does not affect unhexable' do
+      lines = audit_log.keys.join("\n")
+      expect(AuditLogParser.parse(lines, unhex: true)).to eq audit_log.values
     end
 
     context 'when flatten' do

--- a/spec/audit_log_parser_spec.rb
+++ b/spec/audit_log_parser_spec.rb
@@ -1,15 +1,4 @@
 RSpec.describe AuditLogParser do
-  let(:unhex_audit_log) do
-    {
-      %q{type=PROCTITLE msg=audit(1585655101.154:27786): proctitle=2F62696E2F7368002D6300636F6D6D616E64202D762064656269616E2D736131203E202F6465762F6E756C6C2026262064656269616E2D73613120312031} => 
-      {"header"=>{"type"=>"PROCTITLE", "msg"=>"audit(1585655101.154:27786)"},
-      "body"=>
-        {
-          "proctitle" => "/bin/sh\u0000-c\u0000command -v debian-sa1 > /dev/null && debian-sa1 1 1", 
-        }
-      }
-    }
-  end
   let(:audit_log) do
     {
       %q{type=SYSCALL msg=audit(1364481363.243:24287): arch=c000003e syscall=2 success=no exit=-13 a0=7fffd19c5592 a1=0 a2=7fffd19c4b50 a3=a items=1 ppid=2686 pid=3538 auid=500 uid=500 gid=500 euid=500 suid=500 fsuid=500 egid=500 sgid=500 fsgid=500  tty=pts0 ses=1 comm="cat" exe="/bin/cat" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key="sshd_config"} =>
@@ -106,21 +95,54 @@ RSpec.describe AuditLogParser do
       expect(AuditLogParser.parse(lines)).to eq audit_log.values
     end
 
-    specify '#parse correctly unhex proctitle' do
-      lines = unhex_audit_log.keys.join("\n")
-      expect(AuditLogParser.parse(lines, unhex: true)).to eq unhex_audit_log.values
-    end
-
     specify '#parse unhex does not affect unhexable' do
       lines = audit_log.keys.join("\n")
       expect(AuditLogParser.parse(lines, unhex: true)).to eq audit_log.values
     end
+
 
     context 'when flatten' do
       specify '#parse can be parsed flatly' do
         lines = audit_log.keys.join("\n")
         expect(AuditLogParser.parse(lines, flatten: true)).to eq audit_log.values.map {|i| flatten(i) }
       end
+    end
+  end
+
+  context 'when unhex log' do
+    let(:unhex_audit_log) do
+      {
+        %q{type=PROCTITLE msg=audit(1585655101.154:27786): proctitle=2F62696E2F7368002D6300636F6D6D616E64202D762064656269616E2D736131203E202F6465762F6E756C6C2026262064656269616E2D73613120312031} => 
+        {"header"=>{"type"=>"PROCTITLE", "msg"=>"audit(1585655101.154:27786)"},
+        "body"=>
+          {
+            "proctitle" => "/bin/sh\u0000-c\u0000command -v debian-sa1 > /dev/null && debian-sa1 1 1", 
+          }
+        }
+      }
+    end
+
+    let(:unhex_specific_audit_log) do
+      {
+        %q{type=PROCTITLE msg=audit(1585655101.154:27786): proctitle=2F62696E2F7368002D6300636F6D6D616E64202D762064656269616E2D736131203E202F6465762F6E756C6C2026262064656269616E2D73613120312031 proctitle2=2F62696E2F7368002D6300636F6D6D616E64202D762064656269616E2D736131203E202F6465762F6E756C6C2026262064656269616E2D73613120312031 } => 
+        {"header"=>{"type"=>"PROCTITLE", "msg"=>"audit(1585655101.154:27786)"},
+        "body"=>
+          {
+            "proctitle" => "2F62696E2F7368002D6300636F6D6D616E64202D762064656269616E2D736131203E202F6465762F6E756C6C2026262064656269616E2D73613120312031", 
+            "proctitle2" => "/bin/sh\u0000-c\u0000command -v debian-sa1 > /dev/null && debian-sa1 1 1", 
+          }
+        }
+      }
+    end
+
+    specify '#parse correctly unhex proctitle' do
+      lines = unhex_audit_log.keys.join("\n")
+      expect(AuditLogParser.parse(lines, unhex: true)).to eq unhex_audit_log.values
+    end
+
+    specify '#parse correctly unhex specific keys' do
+      lines = unhex_specific_audit_log.keys.join("\n")
+      expect(AuditLogParser.parse(lines, unhex: true, unhex_keys: ['proctitle2'])).to eq unhex_specific_audit_log.values
     end
   end
 

--- a/spec/audit_log_parser_spec.rb
+++ b/spec/audit_log_parser_spec.rb
@@ -135,6 +135,18 @@ RSpec.describe AuditLogParser do
       }
     end
 
+    let(:unhex_length_audit_log) do
+      {
+        %q{type=PROCTITLE msg=audit(1585655101.154:27786): proctitle=2F62696E2F7368002D6300636F6D6D616E64202D762064656269616E2D736131203E202F6465762F6E756C6C2026262064656269616E2D73613120312031 } => 
+        {"header"=>{"type"=>"PROCTITLE", "msg"=>"audit(1585655101.154:27786)"},
+        "body"=>
+          {
+            "proctitle" => "2F62696E2F7368002D6300636F6D6D616E64202D762064656269616E2D736131203E202F6465762F6E756C6C2026262064656269616E2D73613120312031", 
+          }
+        }
+      }
+    end
+
     specify '#parse correctly unhex proctitle' do
       lines = unhex_audit_log.keys.join("\n")
       expect(AuditLogParser.parse(lines, unhex: true)).to eq unhex_audit_log.values
@@ -143,6 +155,11 @@ RSpec.describe AuditLogParser do
     specify '#parse correctly unhex specific keys' do
       lines = unhex_specific_audit_log.keys.join("\n")
       expect(AuditLogParser.parse(lines, unhex: true, unhex_keys: ['proctitle2'])).to eq unhex_specific_audit_log.values
+    end
+
+    specify '#parse does not unhex short keys' do
+      lines = unhex_length_audit_log.keys.join("\n")
+      expect(AuditLogParser.parse(lines, unhex: true, unhex_keys: ['proctitle'], unhex_min_length: 10000)).to eq unhex_length_audit_log.values
     end
   end
 


### PR DESCRIPTION
This PR adds an optional keyword flag `unhex`, `unhex_min_length` and `unhex_keys` to AuditLogParser#parse which unhex's audit values. To use it, simply pass `unhex:true` as in 
```AuditLogParser.parse(lines, unhex: true)```

- `unhex` should unhexing be applied?
- `unhex_keys ` array of lower-case string keys that should be unhexed
- `unhex_min_length` the minimum length of the value at which to match., useful for filtering out
  certain keys that look like they can be unhexed, but are actually too short.

**Why is this necessary?**
Even when the audit library on Linux is configured to use *enriched* logs as below
```
#
# This file controls the configuration of the audit daemon
#
local_events = yes
write_logs = yes
log_file = /var/log/audit/audit.log
log_group = adm
log_format = ENRICHED
```

It still generates some messages that contain hexed values, for example this proctitle line:
```
type=PROCTITLE msg=audit(1585657021.230:27823): proctitle=2F62696E2F7368002D63002020206364202F2026262072756E2D7061727473202D2D7265706F7274202F6574632F63726F6E2E686F75726C79
```

By enabling unhex, you can have this be converted to the correct string value:

```
/bin/sh\x00-c   cd / && run-parts --report /etc/cron.hourly
```

